### PR TITLE
update for compatibility with python3

### DIFF
--- a/i3msg.py
+++ b/i3msg.py
@@ -17,7 +17,10 @@ def get_i3sockpath():
     return i3sockpath
 
 def encode(n, msg=''):
-    return 'i3-ipc' + struct.pack('I', len(msg)) + struct.pack('I', n) + msg
+    return b"".join([str.encode('i3-ipc'), 
+        struct.pack('I', len(msg)),
+        struct.pack('I', n), 
+        str.encode(msg)])
 
 def decode(blob):
     size = int(struct.unpack('I', blob[ 6:10])[0])


### PR DESCRIPTION
Hey! 

I start using your i3msg-python project and was unable to do so using python3, like strings now need to be explicitly casted for concatenation with byte strings. 


My small sample script
```python
import i3msg as i3
print(i3.send(i3.GET_CONFIG))
```
threw the following error (only using python3 -- in python2 it works just fine)
```bash
> python3 info.py
Traceback (most recent call last):
  File "info.py", line 2, in <module>
    print(i3.send(i3.GET_CONFIG))
  File "/mnt/data/repos/i3msg-python/i3msg.py", line 36, in send
    s.send(encode(n, str(msg)))
  File "/mnt/data/repos/i3msg-python/i3msg.py", line 20, in encode
    return 'i3-ipc' + struct.pack('I', len(msg)) + struct.pack('I', n) + msg
TypeError: must be str, not bytes
```
that is now solved with the changes provided in the pull request.

